### PR TITLE
fix bgapi race

### DIFF
--- a/lib/esl/connection.js
+++ b/lib/esl/connection.js
@@ -236,8 +236,6 @@ Connection.prototype.api = function(command, args, cb) {
 // it's own thread. This will be executed in it's own thread, and is non-blocking.
 //
 //bgapi($command, $args) is identical to sendRecv("bgapi $command $args")
-//
-//NOTE: Custom jobid is not currently implemented
 Connection.prototype.bgapi = function(command, args, jobid, cb) {
     if(typeof args === 'function') {
         cb = args;
@@ -260,19 +258,49 @@ Connection.prototype.bgapi = function(command, args, jobid, cb) {
 
     var self = this, params = {};
 
-    if(jobid) params['Job-UUID'] = jobid;
+    var addToFilter      = function(cb) { if (cb) cb() };
+    var removeFromFilter = function(cb) { if (cb) cb() };
+    var sendApiCommand   = function(cb) {
+        if(jobid) params['Job-UUID'] = jobid;
 
-    self.sendRecv('bgapi ' + command + args, params, function(evt) {
-        //got the command reply, use the Job-UUID to call user callback
-        if (self.usingFilters)
-            self.filter('Job-UUID', evt.getHeader('Job-UUID'), function() {
-                if (cb)
-                    self.once('esl::event::BACKGROUND_JOB::' + evt.getHeader('Job-UUID'), cb);
+        addToFilter(function() {
+            self.sendRecv('bgapi ' + command + args, params, function(evt) {
+                //got the command reply, use the Job-UUID to call user callback
+                if (cb) {
+                    self.once('esl::event::BACKGROUND_JOB::' + evt.getHeader('Job-UUID'), function(evt) {
+                        removeFromFilter(function() {
+                            cb(evt);
+                        });
+                    });
+                }
+                else {
+                    removeFromFilter();
+                }
             });
-        else
-            if (cb)
-                self.once('esl::event::BACKGROUND_JOB::' + evt.getHeader('Job-UUID'), cb);
-    });
+        });
+    };
+
+    if (self.usingFilters) {
+        addToFilter = function(cb) {
+            self.filter('Job-UUID', jobid, cb);
+        };
+        removeFromFilter = function(cb) {
+            self.filter_delete('Job-UUID', jobid, cb);
+        };
+
+        if (jobid == undefined) {
+            self.api('create_uuid', function(evt) {
+                jobid = evt.getBody();
+                sendApiCommand(cb);
+            });
+        }
+        else {
+            sendApiCommand(cb);
+        }
+    }
+    else {
+        sendApiCommand(cb);
+    }
 };
 
 //NOTE: This is a wrapper around sendRecv, that uses an ESLevent for the data


### PR DESCRIPTION
Commit 69fc2764f5b added support for adding bgapi Job-UUIDs to the filter list if filters are in use, but it had several issues
- The filter rule was never removed, potentially leading to resource bloat
- There is a race condition adding the filter rule, and if the job completes before the filter is updated, the callback will be missed

This PR fixes both problems
