### PR TITLE
Fix protocol mis-read with utf8 (issue #8)

### DIFF
--- a/lib/esl/parser.js
+++ b/lib/esl/parser.js
@@ -10,7 +10,8 @@ var Parser = exports.Parser = function(socket) {
 
     this.socket = socket;
 
-    this.socket.setEncoding('ascii');
+    // JSON is utf8
+    this.socket.setEncoding('utf8');
 
     this.buffer = '';
     this.bodyLen = 0;
@@ -72,13 +73,15 @@ Parser.prototype._parseHeaders = function() {
 };
 
 Parser.prototype._parseBody = function() {
-    //haven't buffered the entire body yet
-    if(this.buffer.length < this.bodyLen)
+    //haven't buffered the entire body yet.  check using byte-length,
+    //which is the units in which Content-Length is specified
+    var buf = new Buffer(this.buffer);
+    if(buf.length < this.bodyLen)
         return;
 
-    //pull out body text
-    var body = this.buffer.substring(0, this.bodyLen);
-    this.buffer = this.buffer.substring(this.bodyLen);
+    //pull out body text using byte length
+    var body = buf.slice(0, this.bodyLen).toString('utf8');
+    this.buffer = buf.slice(this.bodyLen).toString('utf8');
 
     this.bodyLen = 0;
 
@@ -140,8 +143,10 @@ Parser.prototype._parsePlainBody = function(txt) {
     if(headers['Content-Length']) {
         var len = parseInt(headers['Content-Length'], 10);
 
-        //do count with substr instead of index with substring this time
-        headers._body = txt.substr(headerEnd + 2, len);
+        //extract body using byte-length
+        var bodyStart = headerEnd + 2;
+        var bodyEnd = bodyStart + len;
+        headers._body = Buffer(txt).slice(bodyStart, bodyEnd).toString('utf8');
     }
 
     return headers;


### PR DESCRIPTION
This addresses the issue I observed where multi-byte utf8 data in the JSON payload would cause the parser to get into a bad state

By reading the stream as utf8, but then splitting it using byte-lengths via Buffer, we keep the data as intended but read the correct length off the wire, and avoid short or long reads
