### PR TITLE
make it safe to call disconnect multiple times

### DIFF
--- a/lib/esl/connection.js
+++ b/lib/esl/connection.js
@@ -508,9 +508,11 @@ Connection.prototype.setEventLock = function(value) {
 //Close the socket connection to the FreeSWITCH server.
 Connection.prototype.disconnect = function() {
     this.send('exit');
-    this.socket.end();
 
-    this.socket = null;
+    if (this.socket) {
+        this.socket.end();
+        this.socket = null;
+    }
 };
 
 /*********************


### PR DESCRIPTION
If for some reason disconnect is called multiple times, don't throw an exception
