### PR TITLE
use Buffer until last moment to avoid byte-length issues for garbage dat...

### DIFF
--- a/lib/esl/parser.js
+++ b/lib/esl/parser.js
@@ -8,12 +8,11 @@ xml2js = require('xml2js');
 var Parser = exports.Parser = function(socket) {
     events.EventEmitter.call(this);
 
-    this.buffer = '';
+    this.buffer = new Buffer([]);
     this.bodyLen = 0;
     this.encoding = 'utf8';
 
     this.socket = socket;
-    this.socket.setEncoding(this.encoding);
 
     this.event = null;
 
@@ -24,7 +23,7 @@ var Parser = exports.Parser = function(socket) {
 utile.inherits(Parser, events.EventEmitter);
 
 Parser.prototype._onData = function(data) {
-    this.buffer += data;
+    this.buffer = Buffer.concat([this.buffer, data], this.buffer.length + data.length);
 
     //if we have found a Content-Length header, parse as body
     if(this.bodyLen > 0)
@@ -37,20 +36,38 @@ Parser.prototype._onData = function(data) {
 Parser.prototype._onEnd = function() {
 };
 
+function findNewlineInBuffer(buffer, start, double) {
+    for (var i = start || 0; i < buffer.length; i++) {
+        if (buffer[i] == 0x0a) {
+            if (double) {
+                // Need to find a '\n\n'
+                if (buffer[i + 1] == 0x0a) {
+                    return i;
+                }
+            }
+            else {
+                return i;
+            }
+        }
+    }
+    return null;
+}
+
 Parser.prototype._parseHeaders = function() {
     //get end of header marker
-    var headEnd = this.buffer.indexOf('\n\n'),
+    var headEnd = findNewlineInBuffer(this.buffer, 0, true),
     headText;
 
     //if the headers haven't ended yet, keep buffering
-    if(headEnd < 0)
+    if(headEnd === null) {
         return;
+    }
 
     //if the headers have ended pull out the header text
-    headText = this.buffer.substring(0, headEnd);
+    headText = this.buffer.toString(this.encoding, 0, headEnd);
 
     //remove header text from buffer
-    this.buffer = this.buffer.substring(headEnd + 2);
+    this.buffer = this.buffer.slice(headEnd + 2);
 
     //parse text into object
     this.headers = this._parseHeaderText(headText);
@@ -73,15 +90,13 @@ Parser.prototype._parseHeaders = function() {
 
 Parser.prototype._parseBody = function() {
     //haven't buffered the entire body yet
-    if(Buffer.byteLength(this.buffer, this.encoding) < this.bodyLen)
+    if(this.buffer.length < this.bodyLen)
         return;
 
-    //create a real buffer with the data, and pull out the body
-    //using byte lengths
-    var buf = new Buffer(this.buffer),
-        body = buf.slice(0, this.bodyLen).toString(this.encoding);
+    //pull out the body
+    var body = this.buffer.slice(0, this.bodyLen).toString(this.encoding);
 
-    this.buffer = buf.slice(this.bodyLen).toString(this.encoding);
+    this.buffer = this.buffer.slice(this.bodyLen);
     this.bodyLen = 0;
 
     //create the event


### PR DESCRIPTION
Avoid interpreting wire data as utf-8 as long as possible to avoid misunderstandings about the length of the received data
