### PR TITLE
Checking Application Name before calling execute callback

### DIFF
--- a/lib/esl/connection.js
+++ b/lib/esl/connection.js
@@ -696,7 +696,16 @@ Connection.prototype._doExec = function(uuid, cmd, args, cb) {
 
     cb = cb || this._noop;
 
-    this.once('esl::event::CHANNEL_EXECUTE_COMPLETE::' + uuid, cb);
+    var appName = args["execute-app-name"], handler, self = this;
+    this.on('esl::event::CHANNEL_EXECUTE_COMPLETE::' + uuid, handler = function(e){
+        for(var i=0; i< e.headers.length; i++){
+            if(e.headers[i].name == "Application" && e.headers[i].value == appName){
+                self.off('esl::event::CHANNEL_EXECUTE_COMPLETE::' + uuid, handler);
+                cb(e);
+                break;
+            }
+        }
+    });
 
     this.send('sendmsg ' + uuid, args);
 };


### PR DESCRIPTION
I needed to break a command and continue running other commands, but this way you handled execute_complete event to calling back execute method would cause it to run wrong command callback.
for example I wanted to break a bridge command or playback command in some special cases, but when I ran break command it first calls back bridge callback with wrong event from break execute_complete and then it calls back break cb with the bridge command execute_complete event.
