### PR TITLE
Improvement of esl.Connection.message

### DIFF
--- a/lib/esl/connection.js
+++ b/lib/esl/connection.js
@@ -654,10 +654,15 @@ Connection.prototype.originate = function(profile, gateway, number, app, sync, c
 };
 
 //send a SIP MESSAGE
-Connection.prototype.message = function(to, from, profile, body, cb) {
+Connection.prototype.message = function(to, from, profile, body, subject, deliveryConfirmation, cb) {
     if(typeof subject === 'function') {
         cb = subject;
         subject = '';
+        deliveryConfirmation = false;
+    }
+    else if(typeof deliveryConfirmation === 'function') {
+        cb = deliveryConfirmation;
+        deliveryConfirmation = false;
     }
 
     var event = new esl.Event('custom', 'SMS::SEND_MESSAGE');
@@ -670,7 +675,11 @@ Connection.prototype.message = function(to, from, profile, body, cb) {
 
     event.addHeader('to', to);
     event.addHeader('sip_profile', profile);
-    event.addHeader('subject', 'SIMPLE MESSAGE');
+    event.addHeader('subject', subject);
+
+    if( deliveryConfirmation) {
+        event.addHeader('blocking', 'true');
+    }
 
     event.addHeader('type', 'text/plain');
     event.addHeader('Content-Type', 'text/plain');


### PR DESCRIPTION
Fixed: missing subject argument in esl.Connection.message. Added: deliveryConfirmation argument in esl.Connection.message

I needed to make messages delivery confirmation. So, after some researh, I founded [this](https://github.com/FreeSWITCH/FreeSWITCH/commit/b8f0d11a8a32446637ff6ef3d783a0cd68bc5abf): if you set header 'blocking' in event SMS::SEND_MESSAGE, mod_sms will fire SMS::SEND_MESSAGE with delivery status in header 'Delivery-Failure'. 

If everything is ok, could you also update package in npm?
