### PR TITLE
Commands which replies -USAGE aren't handled

### DIFF
--- a/lib/esl/Parser.js
+++ b/lib/esl/Parser.js
@@ -200,6 +200,8 @@ Parser.prototype._parseEvent = function(headers, body) {
     if(reply) {
         if(reply.indexOf('-ERR') === 0) {
             event.addHeader('Modesl-Reply-ERR', reply.substring(5));
+        } else if(reply.indexOf('-USAGE:') === 0) {
+            event.addHeader('Modesl-Reply-ERR', reply.substring(8));
         } else if(reply.indexOf('+OK') === 0) {
             event.addHeader('Modesl-Reply-OK', reply.substring(4));
         }


### PR DESCRIPTION
When executing a command (but just some commands) with the wrong syntax (ex: originate FOOBAR) the reply is neither "+OK" or "-ERR" but instead "-USAGE:". This isn't at all handled (https://github.com/englercj/node-esl/blob/master/lib/esl/Parser.js#L198-L206).

The spec doesn't say anything about that and the API replies aren't really standardised.
I think that we can assume that "-USAGE:" means false for practical reasons.