### PR TITLE
Corrected typo in disconnection case in connection.js

### DIFF
--- a/lib/esl/Connection.js
+++ b/lib/esl/Connection.js
@@ -530,7 +530,7 @@ Connection.prototype.auth = function(cb) {
             if(cb && typeof cb === 'function') cb(null, evt);
         } else {
             self.authed = false;
-            self.emit('esl::event::auth::fail', new Error('Authentication Failed'), evt);
+            self.emit('esl::event::auth::fail', evt);
 
             if(cb && typeof cb === 'function') cb(new Error('Authentication Failed'), evt);
         }
@@ -725,11 +725,6 @@ Connection.prototype._onError = function(err) {
     this.emit('error', err);
 };
 
-//called on connection disconnection notice, simply echo the event
-//to the user
-Connection.prototype._onDisconnect = function(evt){
-    this.emit('disconnect', evt);
-};
 
 //called when socket connects to FSW ESL Server
 //or when we successfully listen to the fd
@@ -750,8 +745,6 @@ Connection.prototype._onConnect = function() {
     //wait for auth request
     this.on('esl::event::auth::request', this.auth.bind(this));
 
-    //handle auth fail callbacks
-    this.on('esl::event::auth::fail', this._onError.bind(this));
 };
 
 //When we get a generic ESLevent from FSW


### PR DESCRIPTION
fix for https://github.com/englercj/node-esl/issues/37
