### PR TITLE
Fixed callback never called for bgapi

### DIFF
--- a/lib/esl/Connection.js
+++ b/lib/esl/Connection.js
@@ -268,19 +268,16 @@ Connection.prototype.bgapi = function(command, args, jobid, cb) {
             if(jobid) params['Job-UUID'] = jobid;
 
             addToFilter(function() {
-                self.sendRecv('bgapi ' + command + args, params, function(evt) {
-                    //got the command reply, use the Job-UUID to call user callback
-                    if(cb) {
-                        self.once('esl::event::BACKGROUND_JOB::' + evt.getHeader('Job-UUID'), function(evt) {
-                            removeFromFilter(function() {
-                                cb(evt);
-                            });
+                if(cb) {
+                    self.once('esl::event::BACKGROUND_JOB::' + jobid, function(evt) {
+                        removeFromFilter(function() {
+                            cb(evt);
                         });
-                    }
-                    else {
-                        removeFromFilter();
-                    }
-                });
+                    });
+                } else {
+                    removeFromFilter();
+                }
+                self.sendRecv('bgapi ' + command + args, params);
             });
         };
 


### PR DESCRIPTION
In some cases the command replies before attaching the event listener for the reply. When this happens the callback is never called.

Is there a particular reason for which the jobid is taken from the event header given that in all cases it is available?