### PR TITLE
Upgrading `eventemitter2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "lib/index",
   "dependencies": {
-    "eventemitter2": "~0.4",
+    "eventemitter2": "^4.1",
     "node-uuid": "~1.4",
     "xml2js": "~0.4"
   },


### PR DESCRIPTION
- this fixes memory leak in `bgapi` for #69 