### PR TITLE
Issue #84 -- emit esl::end on socket::close

### DIFF
--- a/src/esl/Connection.ts
+++ b/src/esl/Connection.ts
@@ -110,7 +110,7 @@ export class Connection extends EventEmitter2
         });
 
         // Emit end when stream closes
-        socket.on('end', () =>
+        socket.on('close', () =>
         {
             this.emit(ConnectionEvent.End);
         });


### PR DESCRIPTION
net.Socket emits "end" only on successful closing, but it emits "close" in error conditions as well.