### PR TITLE
Issue #84 -- emit esl::end on socket::close

### DIFF
--- a/lib/esl/Connection.js
+++ b/lib/esl/Connection.js
@@ -98,7 +98,7 @@ var Connection = module.exports = function() {
     }
 
     //emit end when stream closes
-    this.socket.on('end', function() {
+    this.socket.on('close', function() {
         self.emit('esl::end');
         self.socket = null;
     });


### PR DESCRIPTION
net.Socket emits "end" only on successful closing, but it emits "close" in error conditions as well.